### PR TITLE
eliminate need for npm install

### DIFF
--- a/content/StsServerIdentity/StsServerIdentity.csproj
+++ b/content/StsServerIdentity/StsServerIdentity.csproj
@@ -20,4 +20,15 @@
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.0" />
   </ItemGroup>
+   
+   <Target Name="DebugEnsureNodeEnv" BeforeTargets="Build" Condition=" '$(Configuration)' == 'Debug' And !Exists('node_modules') ">
+    <!-- Ensure Node.js is installed -->
+    <Exec Command="node --version" ContinueOnError="true">
+      <Output TaskParameter="ExitCode" PropertyName="ErrorCode" />
+    </Exec>
+    <Error Condition="'$(ErrorCode)' != '0'" Text="Node.js is required to build and run this project. To continue, please install Node.js from https://nodejs.org/, and then restart your command prompt or IDE." />
+    <Message Importance="high" Text="Restoring dependencies using 'npm'. This may take several minutes..." />
+    <Exec WorkingDirectory="" Command="npm install" />
+  </Target>
+   
 </Project>


### PR DESCRIPTION
Inspired from asp.net core spa templates, this will eliminate need for npm install when running identity server. First build will trigger npm install and give appropriate feedback if user's machine don't have node installed etc. Therefore, following instruction from readme can be removed as well.

"Install the npm packages, either using the cmd with NodeJS, or Visual Studio"