### PR TITLE
Resolve typo in class attribute

### DIFF
--- a/content/StsServerIdentity/Views/Account/Login.cshtml
+++ b/content/StsServerIdentity/Views/Account/Login.cshtml
@@ -49,7 +49,7 @@
 
     @if (Model.ExternalProviders.Any())
     {
-        <div class="class=" col col-md-6">
+        <div class="col col-md-6">
             <div class="panel-body">
                 <ul class="list-inline">
                     @foreach (var provider in Model.ExternalProviders)


### PR DESCRIPTION
Fairly self-explanatory syntax error in `login.cshtml`