### PR TITLE
Update AccountController.cs

### DIFF
--- a/content/StsServerIdentity/Controllers/AccountController.cs
+++ b/content/StsServerIdentity/Controllers/AccountController.cs
@@ -357,7 +357,7 @@ namespace StsServerIdentity.Controllers
         [HttpPost]
         [AllowAnonymous]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> ExternalLoginConfirmation(ExternalLoginConfirmationViewModel model, string returnUrl = null)
+        public async Task<IActionResult> ExternalLoginConfirmation(ExternalLoginConfirmationViewModel model, string returnUrl = null, string loginProvider = null)
         {
             if (ModelState.IsValid)
             {
@@ -383,6 +383,7 @@ namespace StsServerIdentity.Controllers
             }
 
             ViewData["ReturnUrl"] = returnUrl;
+            ViewData["LoginProvider"] = loginProvider;
             return View(model);
         }
 


### PR DESCRIPTION
if an error occurs and the same view is re-rendered, there is an error because LoginProvider has not been preserved. This file (and one other file I'll edit shortly) need a small tweak to remedy the situation.