### PR TITLE
Support for custom namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # An ASP.NET Core IdentityServer4 Identity Template with Bootstrap 4 and Localization
 
- [![Build status](https://ci.appveyor.com/api/projects/status/ibm36ev49bpjf3o9?svg=true)](https://ci.appveyor.com/project/damienbod/identityserver4aspnetcoreidentitytemplate)      [![NuGet Status](http://img.shields.io/nuget/v/IdentityServer4AspNetCoreIdentityTemplate.svg?style=flat-square)](https://www.nuget.org/packages/IdentityServer4AspNetCoreIdentityTemplate/)  [Change log](https://github.com/damienbod/IdentityServer4AspNetCoreIdentityTemplate/blob/master/Changelog.md) 
+[![Build status](https://ci.appveyor.com/api/projects/status/ibm36ev49bpjf3o9?svg=true)](https://ci.appveyor.com/project/damienbod/identityserver4aspnetcoreidentitytemplate) [![NuGet Status](http://img.shields.io/nuget/v/IdentityServer4AspNetCoreIdentityTemplate.svg?style=flat-square)](https://www.nuget.org/packages/IdentityServer4AspNetCoreIdentityTemplate/) [Change log](https://github.com/damienbod/IdentityServer4AspNetCoreIdentityTemplate/blob/master/Changelog.md)
 
 ## Features
 
@@ -15,7 +15,7 @@
 - Azure AD, Cert, key vault deployments API
 - SendGrid Email API
 - npm with bundleconfig used for frontend packages
-- EF Core 
+- EF Core
 - Support for ui_locales using OIDC logins
 
 some print screens:
@@ -40,7 +40,6 @@ zh-Hans
 
 <img src="https://github.com/damienbod/IdentityServer4AspNetCoreIdentityTemplate/blob/master/images/zh-Hans_template.png" alt=""  />
 
-
 ## Using the template
 
 ### install
@@ -53,16 +52,25 @@ dotnet new -i IdentityServer4AspNetCoreIdentityTemplate
 
 Locally built nupkg:
 
-
 ```
 dotnet new -i IdentityServer4AspNetCoreIdentityTemplate.4.0.0.nupkg
 ```
 
-### run 
+Local folder:
 
 ```
-dotnet new sts
+dotnet new -i <PATH>
 ```
+
+Where `<PATH>` is the path to the folder containing .template.config.
+
+### run
+
+```
+dotnet new sts -n YourCompany.Sts
+```
+
+Use the `-n` or `--name` parameter to change the name of the output created. This string is also used to substitute the namespace name in the .cs file for the project.
 
 ### Setup, Using the application for your System
 
@@ -125,7 +133,7 @@ Get-ChildItem -Path cert:\localMachine\my\"The thumbprint..." | Export-PfxCertif
 - Sendgrid
 - NWebsec.AspNetCore.Middleware
 - Serilog
-	
+
 ## Links
 
 http://docs.identityserver.io/en/release/

--- a/content/StsServerIdentity/.template.config/template.json
+++ b/content/StsServerIdentity/.template.config/template.json
@@ -1,13 +1,16 @@
 {
     "author": "damienbod",
-    "classifications": [ "AspNetCore", "IdentityServer4", "Identity" ],
-    "name": "ASP.NET Core IdentityServer4 Identity",
+    "classifications": [
+        "AspNetCore",
+        "IdentityServer4",
+        "Identity"
+    ],
+    "name": "ASP.NET Core IdentityServer4",
     "identity": "IdentityServer4AspNetCoreIdentityTemplate",
-    "shortName": "id4identity",
+    "shortName": "sts",
     "tags": {
         "language": "C#"
     },
-    "sourceName": "IdentityServer4AspNetCoreIdentityTemplate",
-    "preferNameDirectory" : "true",
-	"shortName": "sts"
+    "sourceName": "StsServerIdentity",
+    "preferNameDirectory": "true"
 }

--- a/content/StsServerIdentity/Models/StsConfig.cs
+++ b/content/StsServerIdentity/Models/StsConfig.cs
@@ -2,7 +2,7 @@
 {
     public class StsConfig
     {
-        public string StsServerIdentityUrl { get; set; }
+        public string StsUrl { get; set; }
         public string ClientUrl { get; set; }
     }
 }

--- a/content/StsServerIdentity/appsettings.Development.json
+++ b/content/StsServerIdentity/appsettings.Development.json
@@ -12,7 +12,7 @@
     "DefaultConnection": "Data Source=usersdatabase.sqlite"
   },
   "StsConfig": {
-    "StsServerIdentityUrl": "https://localhost:44318",
+    "StsUrl": "https://localhost:44318",
     "ClientUrl": "https://localhost:44311"
   },
   "UseLocalCertStore": "true",

--- a/content/StsServerIdentity/appsettings.json
+++ b/content/StsServerIdentity/appsettings.json
@@ -12,7 +12,7 @@
     "DefaultConnection": "__DefaultConnection__"
   },
   "StsConfig": {
-    "StsServerIdentityUrl": "__StsServerIdentityUrl__",
+    "StsUrl": "__StsServerIdentityUrl__",
     "AngularClientUrl": "__AngularClientUrl__",
     "AngularClientIdTokenOnlyUrl": "__AngularClientIdTokenOnlyUrl__"
   },


### PR DESCRIPTION
- Updated the `tempalte.json` file with the proper `SourceName` 
- Updated the `name`
- `shortName` was duplicate
- Had to rename a variable in the `STSConfig.cs` from `StsServerIdentityUrl ` to `StsUrl`, otherwise it would get replaced when creating a new project with the `dotnet new` command

@damienbod is the `StsUrl` property even required? There is no reference to it in code.

closes #48