### PR TITLE
Azure Key Vault certificates

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,13 @@
 
 [Readme](https://github.com/damienbod/IdentityServer4AspNetCoreIdentityTemplate/blob/master/README.md) 
 
+2020-03-14 4.0.2
+- Improved Azure Key Vault certificate handling
+- support for certificate update
+- local certificate support
+- certificates can be loaded using local store and thumbprints
+- Updated localizations it-IT, fr-FR
+
 2020-03-03 4.0.1
 - Added support for FIDO2 MFA
 - Allow clients to request MFA requirement

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ dotnet new -i IdentityServer4AspNetCoreIdentityTemplate
 Locally built nupkg:
 
 ```
-dotnet new -i IdentityServer4AspNetCoreIdentityTemplate.4.0.1.nupkg
+dotnet new -i IdentityServer4AspNetCoreIdentityTemplate.4.0.2.nupkg
 ```
 
 Local folder:

--- a/content/IdentityServer4AspNetCoreIdentityTemplate.nuspec
+++ b/content/IdentityServer4AspNetCoreIdentityTemplate.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
 	<metadata>
 		<id>IdentityServer4AspNetCoreIdentityTemplate</id>
-		<version>4.0.1</version>
+		<version>4.0.2</version>
 		<title>IdentityServer4.Identity.Template</title>
 		<license type="file">LICENSE</license>
 		<description>
@@ -17,7 +17,7 @@
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<copyright>2020 damienbod</copyright>
 		<summary>This template provides a simle getting started for IdentityServer4 with Identity. Identity is Localized and the UI uses Bootstrap 4, Remove AllowAnonymous from the logout</summary>
-		<releaseNotes>Added support for FIDO2 MFA, Support for custom namespaces, Allow clients to request MFA requirement, added amr claim</releaseNotes>
+		<releaseNotes>Improved Azure Key Vault certificate handling, support for certificate update, local certificate support, certificates can be loaded using local store and thumbprints, Updated localizations it-IT, fr-FR</releaseNotes>
 		<repository type="git" url="https://github.com/damienbod/IdentityServer4AspNetCoreIdentityTemplate" />
 		<packageTypes>
 			<packageType name="Template" />

--- a/content/StsServerIdentity/Services/Certificate/CertificateConfiguration.cs
+++ b/content/StsServerIdentity/Services/Certificate/CertificateConfiguration.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace StsServerIdentity.Services.Certificate
+{
+    public class CertificateConfiguration
+    {
+        public bool UseLocalCertStore { get; set; }
+        public string CertificateThumbprint { get; set; }
+        public string CertificateNameKeyVault { get; set; }
+        public string KeyVaultEndpoint { get; set; }
+        public string DevelopmentCertificatePfx { get; set; }
+        public string DevelopmentCertificatePassword { get; set; }
+    }
+}

--- a/content/StsServerIdentity/Services/Certificate/CertificateService.cs
+++ b/content/StsServerIdentity/Services/Certificate/CertificateService.cs
@@ -24,7 +24,7 @@ namespace StsServerIdentity.Services.Certificate
                             certificateConfiguration.KeyVaultEndpoint, 
                             certificateConfiguration.CertificateNameKeyVault);
 
-                    certs = keyVaultCertificateService.GetCertificatesFromKeyVault();
+                    certs = keyVaultCertificateService.GetCertificatesFromKeyVault().GetAwaiter().GetResult();
                 }  
             }
             

--- a/content/StsServerIdentity/Services/Certificate/CertificateService.cs
+++ b/content/StsServerIdentity/Services/Certificate/CertificateService.cs
@@ -4,16 +4,16 @@ namespace StsServerIdentity.Services.Certificate
 {
     public static class CertificateService
     {
-        public static (X509Certificate2, X509Certificate2) GetCertificates(CertificateConfiguration certificateConfiguration)
+        public static (X509Certificate2 ActiveCertificate, X509Certificate2 SecondaryCertificate) GetCertificates(CertificateConfiguration certificateConfiguration)
         {
-            (X509Certificate2, X509Certificate2) certs = (null, null);
+            (X509Certificate2 ActiveCertificate, X509Certificate2 SecondaryCertificate) certs = (null, null);
 
             if (certificateConfiguration.UseLocalCertStore)
             {
                 using X509Store store = new X509Store(StoreName.My, StoreLocation.LocalMachine);
                 store.Open(OpenFlags.ReadOnly);
                 var storeCerts = store.Certificates.Find(X509FindType.FindByThumbprint, certificateConfiguration.CertificateThumbprint, false);
-                certs.Item1 = storeCerts[0];
+                certs.ActiveCertificate = storeCerts[0];
                 store.Close();
             }
             else
@@ -29,9 +29,9 @@ namespace StsServerIdentity.Services.Certificate
             }
             
             // search for local PFX with password, usually local dev
-            if(certs.Item1 == null)
+            if(certs.ActiveCertificate == null)
             {
-                certs.Item1 = new X509Certificate2(
+                certs.ActiveCertificate = new X509Certificate2(
                     certificateConfiguration.DevelopmentCertificatePfx,
                     certificateConfiguration.DevelopmentCertificatePassword);
             }

--- a/content/StsServerIdentity/Services/Certificate/CertificateService.cs
+++ b/content/StsServerIdentity/Services/Certificate/CertificateService.cs
@@ -1,0 +1,42 @@
+﻿using System.Security.Cryptography.X509Certificates;
+
+namespace StsServerIdentity.Services.Certificate
+{
+    public static class CertificateService
+    {
+        public static (X509Certificate2, X509Certificate2) GetCertificates(CertificateConfiguration certificateConfiguration)
+        {
+            (X509Certificate2, X509Certificate2) certs = (null, null);
+
+            if (certificateConfiguration.UseLocalCertStore)
+            {
+                using X509Store store = new X509Store(StoreName.My, StoreLocation.LocalMachine);
+                store.Open(OpenFlags.ReadOnly);
+                var storeCerts = store.Certificates.Find(X509FindType.FindByThumbprint, certificateConfiguration.CertificateThumbprint, false);
+                certs.Item1 = storeCerts[0];
+                store.Close();
+            }
+            else
+            {
+                if (!string.IsNullOrEmpty(certificateConfiguration.KeyVaultEndpoint))
+                {
+                    var keyVaultCertificateService = new KeyVaultCertificateService(
+                            certificateConfiguration.KeyVaultEndpoint, 
+                            certificateConfiguration.CertificateNameKeyVault);
+
+                    certs = keyVaultCertificateService.GetCertificatesFromKeyVault();
+                }  
+            }
+            
+            // search for local PFX with password, usually local dev
+            if(certs.Item1 == null)
+            {
+                certs.Item1 = new X509Certificate2(
+                    certificateConfiguration.DevelopmentCertificatePfx,
+                    certificateConfiguration.DevelopmentCertificatePassword);
+            }
+
+            return certs;
+        }
+    }
+}

--- a/content/StsServerIdentity/Services/Certificate/ICertificateService.cs
+++ b/content/StsServerIdentity/Services/Certificate/ICertificateService.cs
@@ -1,9 +1,0 @@
-﻿using System.Security.Cryptography.X509Certificates;
-
-namespace StsServerIdentity.Services.Certificate
-{
-    public interface ICertificateService
-    {
-        X509Certificate2 GetCertificateFromKeyVault(string vaultCertificateName);
-    }
-}

--- a/content/StsServerIdentity/Services/Certificate/KeyVaultCertificateService.cs
+++ b/content/StsServerIdentity/Services/Certificate/KeyVaultCertificateService.cs
@@ -25,15 +25,7 @@ namespace StsServerIdentity.Services.Certificate
             _certificateName = certificateName; // certificateName
         }
 
-        public (X509Certificate2 ActiveCertificate, X509Certificate2 SecondaryCertificate) GetCertificatesFromKeyVault()
-        {
-            (X509Certificate2 ActiveCertificate, X509Certificate2 SecondaryCertificate) certs = (null, null);
-            Task<(X509Certificate2 ActiveCertificate, X509Certificate2 SecondaryCertificate)> task = Task.Run(async () => await GetCertsAsync());
-            certs = task.Result;
-            return certs;
-        }
-
-        private async Task<(X509Certificate2, X509Certificate2)> GetCertsAsync()
+        public async Task<(X509Certificate2 ActiveCertificate, X509Certificate2 SecondaryCertificate)> GetCertificatesFromKeyVault()
         {
             (X509Certificate2 ActiveCertificate, X509Certificate2 SecondaryCertificate) certs = (null, null);
             var azureServiceTokenProvider = new AzureServiceTokenProvider();

--- a/content/StsServerIdentity/Services/Certificate/KeyVaultCertificateService.cs
+++ b/content/StsServerIdentity/Services/Certificate/KeyVaultCertificateService.cs
@@ -25,17 +25,17 @@ namespace StsServerIdentity.Services.Certificate
             _certificateName = certificateName; // certificateName
         }
 
-        public (X509Certificate2, X509Certificate2) GetCertificatesFromKeyVault()
+        public (X509Certificate2 ActiveCertificate, X509Certificate2 SecondaryCertificate) GetCertificatesFromKeyVault()
         {
-            (X509Certificate2, X509Certificate2) certs = (null, null);
-            Task<(X509Certificate2, X509Certificate2)> task = Task.Run(async () => await GetCertsAsync());
+            (X509Certificate2 ActiveCertificate, X509Certificate2 SecondaryCertificate) certs = (null, null);
+            Task<(X509Certificate2 ActiveCertificate, X509Certificate2 SecondaryCertificate)> task = Task.Run(async () => await GetCertsAsync());
             certs = task.Result;
             return certs;
         }
 
         private async Task<(X509Certificate2, X509Certificate2)> GetCertsAsync()
         {
-            (X509Certificate2, X509Certificate2) certs = (null, null);
+            (X509Certificate2 ActiveCertificate, X509Certificate2 SecondaryCertificate) certs = (null, null);
             var azureServiceTokenProvider = new AzureServiceTokenProvider();
             var keyVaultClient = new KeyVaultClient(new KeyVaultClient.AuthenticationCallback(azureServiceTokenProvider.KeyVaultTokenCallback));
 
@@ -43,12 +43,12 @@ namespace StsServerIdentity.Services.Certificate
             var item = certificateItems.FirstOrDefault();
             if (item != null)
             {
-                certs.Item1 = await GetCertificateAsync(item.Identifier.Identifier, keyVaultClient);
+                certs.ActiveCertificate = await GetCertificateAsync(item.Identifier.Identifier, keyVaultClient);
             }
 
             if (certificateItems.Count > 1)
             {
-                certs.Item2 = await GetCertificateAsync(certificateItems[1].Identifier.Identifier, keyVaultClient);
+                certs.SecondaryCertificate = await GetCertificateAsync(certificateItems[1].Identifier.Identifier, keyVaultClient);
             }
 
             return certs;

--- a/content/StsServerIdentity/Services/Certificate/KeyVaultCertificateService.cs
+++ b/content/StsServerIdentity/Services/Certificate/KeyVaultCertificateService.cs
@@ -1,43 +1,79 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using Microsoft.Azure.KeyVault;
-using Microsoft.IdentityModel.Clients.ActiveDirectory;
+using Microsoft.Azure.KeyVault.Models;
+using Microsoft.Azure.Services.AppAuthentication;
 
 namespace StsServerIdentity.Services.Certificate
 {
-    public class KeyVaultCertificateService : ICertificateService
+    public class KeyVaultCertificateService
     {
-        private readonly string _vaultAddress;
-        private readonly string _vaultClientId;
-        private readonly string _vaultClientSecret;
+        private readonly string _keyVaultEndpoint;
+        private readonly string _certificateName;
 
-        public KeyVaultCertificateService(string vaultAddress, string vaultClientId, string vaultClientSecret)
+        public KeyVaultCertificateService(string keyVaultEndpoint, string certificateName)
         {
-            _vaultAddress = vaultAddress;
-            _vaultClientId = vaultClientId;
-            _vaultClientSecret = vaultClientSecret;
+            if (string.IsNullOrEmpty(keyVaultEndpoint))
+            {
+                throw new ArgumentException("missing keyVaultEndpoint");
+            }
+            
+            _keyVaultEndpoint = keyVaultEndpoint; // "https://damienbod.vault.azure.net"
+            _certificateName = certificateName; // certificateName
         }
 
-        public X509Certificate2 GetCertificateFromKeyVault(string vaultCertificateName)
+        public (X509Certificate2, X509Certificate2) GetCertificatesFromKeyVault()
         {
-            var keyVaultClient = new KeyVaultClient(AuthenticationCallback);
-
-            var certBundle = keyVaultClient.GetCertificateAsync(_vaultAddress, vaultCertificateName).Result;
-            var certContent = keyVaultClient.GetSecretAsync(certBundle.SecretIdentifier.Identifier).Result;
-            var certBytes = Convert.FromBase64String(certContent.Value);
-            var cert = new X509Certificate2(certBytes);
-            return cert;
+            (X509Certificate2, X509Certificate2) certs = (null, null);
+            Task<(X509Certificate2, X509Certificate2)> task = Task.Run(async () => await GetCertsAsync());
+            certs = task.Result;
+            return certs;
         }
 
-        private async Task<string> AuthenticationCallback(string authority, string resource, string scope)
+        private async Task<(X509Certificate2, X509Certificate2)> GetCertsAsync()
         {
-            var clientCredential = new ClientCredential(_vaultClientId, _vaultClientSecret);
+            (X509Certificate2, X509Certificate2) certs = (null, null);
+            var azureServiceTokenProvider = new AzureServiceTokenProvider();
+            var keyVaultClient = new KeyVaultClient(new KeyVaultClient.AuthenticationCallback(azureServiceTokenProvider.KeyVaultTokenCallback));
 
-            var context = new AuthenticationContext(authority, TokenCache.DefaultShared);
-            var result = await context.AcquireTokenAsync(resource, clientCredential);
+            var certificateItems = await GetAllEnabledCertificateVersionsAsync(keyVaultClient);
+            var item = certificateItems.FirstOrDefault();
+            if (item != null)
+            {
+                certs.Item1 = await GetCertificateAsync(item.Identifier.Identifier, keyVaultClient);
+            }
 
-            return result.AccessToken;
+            if (certificateItems.Count > 1)
+            {
+                certs.Item2 = await GetCertificateAsync(certificateItems[1].Identifier.Identifier, keyVaultClient);
+            }
+
+            return certs;
         }
+
+        private async Task<List<CertificateItem>> GetAllEnabledCertificateVersionsAsync( KeyVaultClient keyVaultClient)
+        {
+            // Get all the certificate versions (this will also get the currect active version
+            var certificateVersions = await keyVaultClient.GetCertificateVersionsAsync(_keyVaultEndpoint, _certificateName);
+
+            // Find all enabled versions of the certificate and sort them by creation date in decending order 
+            return certificateVersions
+              .Where(certVersion => certVersion.Attributes.Enabled.HasValue && certVersion.Attributes.Enabled.Value)
+              .OrderByDescending(certVersion => certVersion.Attributes.Created)
+              .ToList();
+        }
+
+        private async Task<X509Certificate2> GetCertificateAsync(string identitifier, KeyVaultClient keyVaultClient)
+        {
+            var certificateVersionBundle = await keyVaultClient.GetCertificateAsync(identitifier);
+            var certificatePrivateKeySecretBundle = await keyVaultClient.GetSecretAsync(certificateVersionBundle.SecretIdentifier.Identifier);
+            var privateKeyBytes = Convert.FromBase64String(certificatePrivateKeySecretBundle.Value);
+            var certificateWithPrivateKey = new X509Certificate2(privateKeyBytes, (string)null, X509KeyStorageFlags.MachineKeySet);
+            return certificateWithPrivateKey;
+        }
+
     }
 }

--- a/content/StsServerIdentity/Startup.cs
+++ b/content/StsServerIdentity/Startup.cs
@@ -219,9 +219,9 @@ namespace StsServerIdentity
                 DevelopmentCertificatePfx = Path.Combine(environment.ContentRootPath, "sts_dev_cert.pfx"),
                 DevelopmentCertificatePassword = "1234" //configuration["DevelopmentCertificatePassword"] //"1234",
 
-                //    // Use a local store with thumbprint
-                //    UseLocalCertStore = Convert.ToBoolean(configuration["UseLocalCertStore"]),
-                //    CertificateThumbprint = configuration["CertificateThumbprint"],
+                //// Use a local store with thumbprint
+                //UseLocalCertStore = Convert.ToBoolean(configuration["UseLocalCertStore"]),
+                //CertificateThumbprint = configuration["CertificateThumbprint"],
             };
 
             (X509Certificate2, X509Certificate2) certs = CertificateService.GetCertificates(

--- a/content/StsServerIdentity/Startup.cs
+++ b/content/StsServerIdentity/Startup.cs
@@ -54,7 +54,7 @@ namespace StsServerIdentity
                     CheckSameSite(cookieContext.Context, cookieContext.CookieOptions);
             });
 
-            var x509Certificate2 = GetCertificate(_environment, _configuration);
+            var x509Certificate2Certs = GetCertificates(_environment, _configuration);
             AddLocalizationConfigurations(services);
 
             services.AddDbContext<ApplicationDbContext>(options =>
@@ -106,13 +106,19 @@ namespace StsServerIdentity
                 .AddNewtonsoftJson();
 
             var stsConfig = _configuration.GetSection("StsConfig");
-            services.AddIdentityServer()
-                .AddSigningCredential(x509Certificate2)
+
+            var identityServer = services.AddIdentityServer()
+                .AddSigningCredential(x509Certificate2Certs.Item1)
                 .AddInMemoryIdentityResources(Config.GetIdentityResources())
                 .AddInMemoryApiResources(Config.GetApiResources())
                 .AddInMemoryClients(Config.GetClients(stsConfig))
                 .AddAspNetIdentity<ApplicationUser>()
                 .AddProfileService<IdentityWithAdditionalClaimsProfileService>();
+
+            if (x509Certificate2Certs.Item2 != null)
+            {
+                identityServer.AddValidationKey(x509Certificate2Certs.Item2);
+            }
 
             services.Configure<Fido2Configuration>(_configuration.GetSection("fido2"));
             services.Configure<Fido2MdsConfiguration>(_configuration.GetSection("fido2mds"));
@@ -201,38 +207,27 @@ namespace StsServerIdentity
             });
         }
 
-        private static X509Certificate2 GetCertificate(IWebHostEnvironment environment, IConfiguration configuration)
+        private static (X509Certificate2, X509Certificate2) GetCertificates(IWebHostEnvironment environment, IConfiguration configuration)
         {
-            X509Certificate2 cert;
-            var useLocalCertStore = Convert.ToBoolean(configuration["UseLocalCertStore"]);
-            var certificateThumbprint = configuration["CertificateThumbprint"];
-
-            if (environment.IsProduction())
+            var certificateConfiguration = new CertificateConfiguration
             {
-                if (useLocalCertStore)
-                {
-                    using (X509Store store = new X509Store(StoreName.My, StoreLocation.LocalMachine))
-                    {
-                        store.Open(OpenFlags.ReadOnly);
-                        var certs = store.Certificates.Find(X509FindType.FindByThumbprint, certificateThumbprint, false);
-                        cert = certs[0];
-                        store.Close();
-                    }
-                }
-                else
-                {
-                    // Azure deployment, will be used if deployed to Azure
-                    var vaultConfigSection = configuration.GetSection("Vault");
-                    var keyVaultService = new KeyVaultCertificateService(vaultConfigSection["Url"], vaultConfigSection["ClientId"], vaultConfigSection["ClientSecret"]);
-                    cert = keyVaultService.GetCertificateFromKeyVault(vaultConfigSection["CertificateName"]);
-                }
-            }
-            else
-            {
-                cert = new X509Certificate2(Path.Combine(environment.ContentRootPath, "sts_dev_cert.pfx"), "1234");
-            }
+                // Use an Azure key vault
+                CertificateNameKeyVault = configuration["CertificateNameKeyVault"], //"StsCert",
+                KeyVaultEndpoint = configuration["AzureKeyVaultEndpoint"], // "https://damienbod.vault.azure.net"
 
-            return cert;
+                // development certificate
+                DevelopmentCertificatePfx = Path.Combine(environment.ContentRootPath, "sts_dev_cert.pfx"),
+                DevelopmentCertificatePassword = configuration["DevelopmentCertificatePassword"] //"1234",
+
+                //    // Use a local store with thumbprint
+                //    UseLocalCertStore = Convert.ToBoolean(configuration["UseLocalCertStore"]),
+                //    CertificateThumbprint = configuration["CertificateThumbprint"],
+            };
+
+            (X509Certificate2, X509Certificate2) certs = CertificateService.GetCertificates(
+                certificateConfiguration);
+
+            return certs;
         }
 
         private static void AddLocalizationConfigurations(IServiceCollection services)

--- a/content/StsServerIdentity/Startup.cs
+++ b/content/StsServerIdentity/Startup.cs
@@ -215,13 +215,13 @@ namespace StsServerIdentity
                 CertificateNameKeyVault = configuration["CertificateNameKeyVault"], //"StsCert",
                 KeyVaultEndpoint = configuration["AzureKeyVaultEndpoint"], // "https://damienbod.vault.azure.net"
 
+                // Use a local store with thumbprint
+                //UseLocalCertStore = Convert.ToBoolean(configuration["UseLocalCertStore"]),
+                //CertificateThumbprint = configuration["CertificateThumbprint"],
+
                 // development certificate
                 DevelopmentCertificatePfx = Path.Combine(environment.ContentRootPath, "sts_dev_cert.pfx"),
                 DevelopmentCertificatePassword = "1234" //configuration["DevelopmentCertificatePassword"] //"1234",
-
-                //// Use a local store with thumbprint
-                //UseLocalCertStore = Convert.ToBoolean(configuration["UseLocalCertStore"]),
-                //CertificateThumbprint = configuration["CertificateThumbprint"],
             };
 
             (X509Certificate2 ActiveCertificate, X509Certificate2 SecondaryCertificate) certs = CertificateService.GetCertificates(

--- a/content/StsServerIdentity/Startup.cs
+++ b/content/StsServerIdentity/Startup.cs
@@ -217,7 +217,7 @@ namespace StsServerIdentity
 
                 // development certificate
                 DevelopmentCertificatePfx = Path.Combine(environment.ContentRootPath, "sts_dev_cert.pfx"),
-                DevelopmentCertificatePassword = configuration["DevelopmentCertificatePassword"] //"1234",
+                DevelopmentCertificatePassword = "1234" //configuration["DevelopmentCertificatePassword"] //"1234",
 
                 //    // Use a local store with thumbprint
                 //    UseLocalCertStore = Convert.ToBoolean(configuration["UseLocalCertStore"]),

--- a/content/StsServerIdentity/Startup.cs
+++ b/content/StsServerIdentity/Startup.cs
@@ -108,16 +108,16 @@ namespace StsServerIdentity
             var stsConfig = _configuration.GetSection("StsConfig");
 
             var identityServer = services.AddIdentityServer()
-                .AddSigningCredential(x509Certificate2Certs.Item1)
+                .AddSigningCredential(x509Certificate2Certs.ActiveCertificate)
                 .AddInMemoryIdentityResources(Config.GetIdentityResources())
                 .AddInMemoryApiResources(Config.GetApiResources())
                 .AddInMemoryClients(Config.GetClients(stsConfig))
                 .AddAspNetIdentity<ApplicationUser>()
                 .AddProfileService<IdentityWithAdditionalClaimsProfileService>();
 
-            if (x509Certificate2Certs.Item2 != null)
+            if (x509Certificate2Certs.SecondaryCertificate != null)
             {
-                identityServer.AddValidationKey(x509Certificate2Certs.Item2);
+                identityServer.AddValidationKey(x509Certificate2Certs.SecondaryCertificate);
             }
 
             services.Configure<Fido2Configuration>(_configuration.GetSection("fido2"));
@@ -207,7 +207,7 @@ namespace StsServerIdentity
             });
         }
 
-        private static (X509Certificate2, X509Certificate2) GetCertificates(IWebHostEnvironment environment, IConfiguration configuration)
+        private static (X509Certificate2 ActiveCertificate, X509Certificate2 SecondaryCertificate) GetCertificates(IWebHostEnvironment environment, IConfiguration configuration)
         {
             var certificateConfiguration = new CertificateConfiguration
             {
@@ -224,7 +224,7 @@ namespace StsServerIdentity
                 //CertificateThumbprint = configuration["CertificateThumbprint"],
             };
 
-            (X509Certificate2, X509Certificate2) certs = CertificateService.GetCertificates(
+            (X509Certificate2 ActiveCertificate, X509Certificate2 SecondaryCertificate) certs = CertificateService.GetCertificates(
                 certificateConfiguration);
 
             return certs;

--- a/content/StsServerIdentity/StsServerIdentity.csproj
+++ b/content/StsServerIdentity/StsServerIdentity.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>4.0.1</Version>
+    <Version>4.0.2</Version>
     <Description>IdentityServer4 template with ASP.NET Core 3.1 and ASP.NET Core Identity</Description>
     <PackageProjectUrl>https://github.com/damienbod/IdentityServer4AspNetCoreIdentityTemplate</PackageProjectUrl>
     <PackageIconUrl>http://www.gravatar.com/avatar/61d005637f57b5c3da8ba662cf04a9d6.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/damienbod/IdentityServer4AspNetCoreIdentityTemplate</RepositoryUrl>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageTags>oidc identityserver4 identity aspnetcore</PackageTags>
-    <PackageReleaseNotes>Added support for FIDO2 MFA, Support for custom namespaces, Allow clients to request MFA requirement, added amr claim</PackageReleaseNotes>
+    <PackageReleaseNotes>Improved Azure Key Vault certificate handling, support for certificate update, local certificate support, certificates can be loaded using local store and thumbprints, Updated localizations it-IT, fr-FR</PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BuildBundlerMinifier" Version="3.2.435" />

--- a/content/StsServerIdentity/appsettings.Development.json
+++ b/content/StsServerIdentity/appsettings.Development.json
@@ -11,12 +11,14 @@
   "ConnectionStrings": {
     "DefaultConnection": "Data Source=usersdatabase.sqlite"
   },
+  "UseLocalCertStore": "false",
+  "CertificateThumbprint": "",
+  "CertificateNameKeyVault": "",
+  "AzureKeyVaultEndpoint": "",
   "StsConfig": {
     "StsUrl": "https://localhost:44318",
     "ClientUrl": "https://localhost:44311"
   },
-  "UseLocalCertStore": "true",
-  "CertificateThumbprint": "TODO_GET_FROM_DEPLOYMENT_SERVER_CERT",
   "EmailSettings": {
     "SendGridApiKey": "TODO_EMAIL_API_KEY",
     "SenderEmailAddress": "TODO_EMAIL_ADDRESS"

--- a/content/StsServerIdentity/appsettings.json
+++ b/content/StsServerIdentity/appsettings.json
@@ -15,8 +15,10 @@
     "StsUrl": "__StsServerIdentityUrl__",
     "ClientUrl": "__ClientUrl__"
   },
-  "UseLocalCertStore": "__UseLocalCertStore__",
-  "CertificateThumbprint": "__CertificateThumbprint__",
+  "UseLocalCertStore": "false",
+  "CertificateThumbprint": "",
+  "CertificateNameKeyVault": "",
+  "AzureKeyVaultEndpoint": "",
   "EmailSettings": {
     "SendGridApiKey": "__SendGridApiKey__",
     "SenderEmailAddress": "__SenderEmailAddress__"


### PR DESCRIPTION
Improve the certificate handling for certificates, form Azure Key Vault, Local Store, or local PFX file. Certificates can now be updated in Azure key vault and the newest certificates will be used for signing, the second newest used for support of old tokens alrighted created.