### PR TITLE
Move synchronization to the top level

### DIFF
--- a/content/StsServerIdentity/Services/Certificate/CertificateService.cs
+++ b/content/StsServerIdentity/Services/Certificate/CertificateService.cs
@@ -1,10 +1,11 @@
 ﻿using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
 
 namespace StsServerIdentity.Services.Certificate
 {
     public static class CertificateService
     {
-        public static (X509Certificate2 ActiveCertificate, X509Certificate2 SecondaryCertificate) GetCertificates(CertificateConfiguration certificateConfiguration)
+        public static async Task<(X509Certificate2 ActiveCertificate, X509Certificate2 SecondaryCertificate)> GetCertificates(CertificateConfiguration certificateConfiguration)
         {
             (X509Certificate2 ActiveCertificate, X509Certificate2 SecondaryCertificate) certs = (null, null);
 
@@ -21,13 +22,13 @@ namespace StsServerIdentity.Services.Certificate
                 if (!string.IsNullOrEmpty(certificateConfiguration.KeyVaultEndpoint))
                 {
                     var keyVaultCertificateService = new KeyVaultCertificateService(
-                            certificateConfiguration.KeyVaultEndpoint, 
+                            certificateConfiguration.KeyVaultEndpoint,
                             certificateConfiguration.CertificateNameKeyVault);
 
-                    certs = keyVaultCertificateService.GetCertificatesFromKeyVault().GetAwaiter().GetResult();
-                }  
+                    certs = await keyVaultCertificateService.GetCertificatesFromKeyVault().ConfigureAwait(false);
+                }
             }
-            
+
             // search for local PFX with password, usually local dev
             if(certs.ActiveCertificate == null)
             {

--- a/content/StsServerIdentity/Startup.cs
+++ b/content/StsServerIdentity/Startup.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.IO;
 using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Identity;
@@ -54,7 +55,8 @@ namespace StsServerIdentity
                     CheckSameSite(cookieContext.Context, cookieContext.CookieOptions);
             });
 
-            var x509Certificate2Certs = GetCertificates(_environment, _configuration);
+            var x509Certificate2Certs = GetCertificates(_environment, _configuration)
+                .GetAwaiter().GetResult();
             AddLocalizationConfigurations(services);
 
             services.AddDbContext<ApplicationDbContext>(options =>
@@ -207,7 +209,7 @@ namespace StsServerIdentity
             });
         }
 
-        private static (X509Certificate2 ActiveCertificate, X509Certificate2 SecondaryCertificate) GetCertificates(IWebHostEnvironment environment, IConfiguration configuration)
+        private static async Task<(X509Certificate2 ActiveCertificate, X509Certificate2 SecondaryCertificate)> GetCertificates(IWebHostEnvironment environment, IConfiguration configuration)
         {
             var certificateConfiguration = new CertificateConfiguration
             {
@@ -224,8 +226,8 @@ namespace StsServerIdentity
                 DevelopmentCertificatePassword = "1234" //configuration["DevelopmentCertificatePassword"] //"1234",
             };
 
-            (X509Certificate2 ActiveCertificate, X509Certificate2 SecondaryCertificate) certs = CertificateService.GetCertificates(
-                certificateConfiguration);
+            (X509Certificate2 ActiveCertificate, X509Certificate2 SecondaryCertificate) certs = await CertificateService.GetCertificates(
+                certificateConfiguration).ConfigureAwait(false);
 
             return certs;
         }
@@ -299,9 +301,9 @@ namespace StsServerIdentity
                 return true;
             }
 
-            // Cover Chrome 50-69, because some versions are broken by SameSite=None, 
+            // Cover Chrome 50-69, because some versions are broken by SameSite=None,
             // and none in this range require it.
-            // Note: this covers some pre-Chromium Edge versions, 
+            // Note: this covers some pre-Chromium Edge versions,
             // but pre-Chromium Edge does not require SameSite=None.
             if (userAgent.Contains("Chrome/5") || userAgent.Contains("Chrome/6"))
             {


### PR DESCRIPTION
Generally it is a good practice to make the async flow go as far as you can until you hit the integration point that doesn't support async. Then that is where you put the synchronization.

The even better practice would be to either:

- Have a hosted service
- Run async stuff that cannot be run in a hosted service in the async program main

The problem here though is that identity server forces you to add the certificate information you retrieve from an IO-bound resource in the service collection extensions and they do not support async by design. In case you wouldn't need configuration access you would be able to entirely bring this up to async main. The hosted service doesn't work because you have to configure identity server during service collection initialization. 

If you would like to go totally async you would need to implement `ISigningCredentialStore` and `IValidationKeysStore` by wrapping the default stores and asynchronously retrieve the certificates. Those interfaces are already design to support async. A believe though this would be overkill here and `GetAwaiter().GetResult()` is therefore a necessary evil.